### PR TITLE
Add support for persistent connection destination change

### DIFF
--- a/relayd/relay_http.c
+++ b/relayd/relay_http.c
@@ -1373,8 +1373,13 @@ relay_match_actions(struct ctl_relay_event *cre, struct relay_rule *rule,
 	/*
 	 * Apply the following options instantly (action per match).
 	 */
-	if (rule->rule_table != NULL)
+	if (rule->rule_table != NULL) {
+		if (con->se_table != rule->rule_table &&
+		    cre->dst->state == STATE_CONNECTED) {
+			relay_disconnect(con, "change destination");
+		}
 		con->se_table = rule->rule_table;
+	}
 
 	if (rule->rule_tag != 0)
 		con->se_tag = rule->rule_tag == -1 ? 0 : rule->rule_tag;

--- a/relayd/relayd.h
+++ b/relayd/relayd.h
@@ -1151,6 +1151,7 @@ int	 relay_spliceadjust(struct ctl_relay_event *);
 void	 relay_error(struct bufferevent *, short, void *);
 int	 relay_preconnect(struct rsession *);
 int	 relay_connect(struct rsession *);
+void	 relay_disconnect(struct rsession *, const char *);
 void	 relay_connected(int, short, void *);
 void	 relay_bindanyreq(struct rsession *, in_port_t, int);
 void	 relay_bindany(int, short, void *);


### PR DESCRIPTION
Leaving this patch here as posting on bugs@ had no responses. May it help someone.

Add a relay_disconnect function that allows to only disconnect se_out
connection and reallocate output buffer for future use.

Uses relay_disconnect in relay_match_action for http if it appears
destination changed
