### PR TITLE
Remove unused parameter (sig)

### DIFF
--- a/relayd/check_script.c
+++ b/relayd/check_script.c
@@ -76,7 +76,7 @@ script_done(struct relayd *env, struct ctl_script *scr)
 }
 
 void
-script_sig_alarm(int sig)
+script_sig_alarm(int)
 {
 	int save_errno = errno;
 


### PR DESCRIPTION
* A function parameter ( sig ) is not used in the body of the function.

   I think, that If the argument is needed for type compatibility or future plans, 
   we have to use /*@unused@*/ in the argument declaration.