### PR TITLE
fixes Websocket upgrade headers

### DIFF
--- a/relayd/relay_http.c
+++ b/relayd/relay_http.c
@@ -524,9 +524,10 @@ relay_read_http(struct bufferevent *bev, void *arg)
 
 		/*
 		 * Ask the server to close the connection after this request
-		 * since we don't read any further request headers.
+		 * since we don't read any further request headers, unless upgrade
+		 * is requested, in which case we do NOT want to add this header.
 		 */
-		if (cre->toread == TOREAD_UNLIMITED)
+		if (cre->toread == TOREAD_UNLIMITED && upgrade == NULL)
 			if (kv_add(&desc->http_headers, "Connection",
 			    "close", 0) == NULL)
 				goto fail;


### PR DESCRIPTION
After migrating my home setup for nginx reverse proxying to relayd, i noticed my iOS devices having issues connecting through Websockets. After debugging, i noticed that relayd adds the "Connection: close" regardless of upgrade being requested.

This issue is also reported on a [blog-post](https://deftly.net/posts/2019-10-23-websockets-with-relayd.html) using relayd as a Websocket Client.
This resulted in the response having two Connection Headers, one "Connection: upgrade" and one "Connection: close", which iOS strict implementation does not allow.

I have fixed the `if` condition and will supply a pull request after submitting this ticket.

The fix has been tested with Apple iOS 13 and the problem can be observed using Firefox and just connecting to something Websocket over relayd. Both headers will appear.

best regards and thank you for your consideration.
