### PR TITLE
add the ability to filter by http status code

### DIFF
--- a/relayd/parse.y
+++ b/relayd/parse.y
@@ -1448,6 +1448,13 @@ ruleopts	: METHOD STRING					{
 			rule->rule_method = id;
 			free($2);
 		}
+		| CODE NUMBER					{
+			if ($2 < 100 || $2 > 599) {
+				yyerror("invalid HTTP code: %lld", $2);
+				YYERROR;
+			}
+			rule->rule_status = $2;
+		}
 		| COOKIE key_option STRING value		{
 			keytype = KEY_TYPE_COOKIE;
 			rule->rule_kv[keytype].kv_key = strdup($3);

--- a/relayd/relay_http.c
+++ b/relayd/relay_http.c
@@ -1816,6 +1816,8 @@ relay_test(struct protocol *proto, struct ctl_relay_event *cre)
 		    (desc->http_method == HTTP_METHOD_RESPONSE ||
 		     desc->http_method != r->rule_method))
 			RELAY_GET_SKIP_STEP(RULE_SKIP_METHOD);
+		else if (r->rule_status && desc->http_status != r->rule_status)
+			RELAY_GET_SKIP_STEP(RULE_SKIP_STATUS);
 		else if (r->rule_tagged && con->se_tag != r->rule_tagged)
 			RELAY_GET_NEXT_STEP;
 		else if (relay_httpheader_test(cre, r, &matches) != 0)
@@ -1917,6 +1919,8 @@ relay_calc_skip_steps(struct relay_rules *rules)
 			RELAY_SET_SKIP_STEPS(RULE_SKIP_DST);
 		else if (cur->rule_method != prev->rule_method)
 			RELAY_SET_SKIP_STEPS(RULE_SKIP_METHOD);
+		else if (cur->rule_status != prev->rule_status)
+			RELAY_SET_SKIP_STEPS(RULE_SKIP_STATUS);
 
 		prev = cur;
 		cur = TAILQ_NEXT(cur, rule_entry);

--- a/relayd/relayd.conf.5
+++ b/relayd/relayd.conf.5
@@ -1205,6 +1205,10 @@ and can be either
 or
 .Ic VERSION-CONTROL .
 .It Xo
+.It Ic code Ar number
+Match the HTTP return code
+.Ar number .
+.It Xo
 .Ar type Ar option
 .Oo Oo Ic digest Oc
 .Pq Ar key Ns | Ns Ic file Ar path

--- a/relayd/relayd.h
+++ b/relayd/relayd.h
@@ -647,7 +647,8 @@ struct relay_rule {
 #define RULE_SKIP_SRC		 3
 #define RULE_SKIP_DST		 4
 #define RULE_SKIP_METHOD	 5
-#define RULE_SKIP_COUNT		 6
+#define RULE_SKIP_STATUS	 6
+#define RULE_SKIP_COUNT		 7
 	struct relay_rule	*rule_skip[RULE_SKIP_COUNT];
 
 #define RULE_FLAG_QUICK		0x01
@@ -664,6 +665,7 @@ struct relay_rule {
 	struct relay_table	*rule_table;
 
 	u_int			 rule_method;
+	u_int			 rule_status;
 	char			 rule_labelname[LABEL_NAME_SIZE];
 	char			 rule_tablename[TABLE_NAME_SIZE];
 	char			 rule_taggedname[TAG_NAME_SIZE];


### PR DESCRIPTION
I recently needed to filter the response of a service not under my control depending on its http-status code, e.g drop all connections which result in a 401. Maybe it is useful for someone else (Was also posted to openbsd-tech).